### PR TITLE
Added linear easing to animations.

### DIFF
--- a/src/Animator.js
+++ b/src/Animator.js
@@ -286,6 +286,9 @@ MathBox.Animator.Animation.prototype = {
       case 'out':
         rolloff = fraction * fraction;
         break;
+      case 'linear':
+        rolloff = fraction;
+        break;
       default:
         rolloff = .5-.5*Math.cos(fraction * π);
         break;


### PR DESCRIPTION
Very useful when you want to create e.g. a continuous rotating graph. Now you
can do:

var n = 0;
var duration = 1000;
var spin = function() {
  mathbox.animate('surface', {
      worldRotation: [0, 0, n++ \* τ]
  }, {
      duration: duration,
      ease: 'linear'
  });
  setTimeout(spin, duration);
};
spin();

For a continuous spin. I'd still like to see better support for this, but full
support would require allowing properties (such as worldRotation above) to be
functions that return the new result instead of being values.
