### PR TITLE
Use TeXZilla when it is present (and MathJax absent).

### DIFF
--- a/src/renderables/Labels.js
+++ b/src/renderables/Labels.js
@@ -111,7 +111,7 @@ MathBox.Renderable.Labels.prototype = _.extend(new MathBox.Renderable(null), {
           }
         }
 
-        if (!mathjax) {
+        if (!mathjax && !window.TeXZilla) {
           text = (''+text).replace(/^-/, '–');
         }
       }
@@ -125,6 +125,9 @@ MathBox.Renderable.Labels.prototype = _.extend(new MathBox.Renderable(null), {
         if (mathjax) {
           inner.innerHTML = "\\(" + text + "\\)";
           MathJax.Hub.queue.Push(["Typeset", MathJax.Hub, inner]);
+        }
+        else if (window.TeXZilla) {
+          inner.innerHTML = window.TeXZilla.toMathMLString(text.toString());
         }
         else {
           inner.innerHTML = text;


### PR DESCRIPTION
This uses [TeXZilla](http://fred-wang.github.io/TeXZilla/) when it is present (for example if one includes http://fred-wang.github.io/TeXZilla/TeXZilla-min.js) to convert the labels to native MathML. This should be more standard, faster and could probably help with the styling of labels. However, this obviously requires a standard-compliant browser. I tested it with WebKit and Gecko with the files in examples/.
