### PR TITLE
fixes fransform from carthesian to spherical coordinates

### DIFF
--- a/src/viewports/ViewportSphere.js
+++ b/src/viewports/ViewportSphere.js
@@ -77,10 +77,9 @@ MathBox.ViewportSphere.prototype = _.extend(new MathBox.ViewportCartesian(null),
           y = vector.y / aspectY,
           z = vector.z * aspectX + focus;
 
-      var radius = Math.sqrt(x*x + y*y + z*z);
-          theta = Math.atan2(y, Math.sqrt(x*x + y*y)),
-          phi = Math.atan2(x, z);
-
+      var radius = Math.sqrt(x*x + y*y + z*z),
+          phi = Math.atan2(y, Math.sqrt(x*x + z*z)),
+          theta = Math.atan2(x, z);
       vector.x = theta / alpha;
       vector.y = phi / alpha * aspectY / yScale;
       vector.z = (radius - focus) / aspectX;


### PR DESCRIPTION
Steps to reproduce:

Open `Empty.html`

```
mathbox.viewport({
  type: 'sphere',
  range: [[-π, π], [-π/2, π/2], [-1, 1]], // Range in X, Y, Z (Longitude, Latitude, Radius)
  sphere: 1,                              // Morph between cartesian (0) and spherical (1)
  scale: [1, 1, 1],                       // Scale in X, Y, Z
  rotation: [0, 0, 0],                    // Viewport rotation in Euler angles
  position: [0, 0, 0],                    // Viewport position in XYZ
}).vector({data:[[0,0,0],[1,2,0.5]]})
```

Arrow and line will be misaligned. 
