### PR TITLE
Occurences of 'innerText' were replaced with 'textContent'

### DIFF
--- a/build/MathBox-bundle.js
+++ b/build/MathBox-bundle.js
@@ -40269,7 +40269,7 @@ window.ThreeRTT = window.ThreeRTT || {};
 // or pass through string if not exists.
 ThreeRTT.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && elem.innerText || id;
+  return elem && elem.textContent || id;
 };
 
 // Simple loop helper
@@ -40280,7 +40280,7 @@ _.loop = function (n, callback) {
 // Fetch shader from <script> tag by id
 ThreeRTT.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && (elem.innerText || elem.textContent) || id;
+  return elem && elem.textContent || id;
 };
 // Check for a power of two.
 ThreeRTT.isPowerOfTwo = function (value) {
@@ -41476,7 +41476,7 @@ window.ShaderGraph = {};
 // Fetch shader from <script> tag by id
 ShaderGraph.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && (elem.innerText || elem.textContent) || id;
+  return elem && elem.textContent || id;
 };(function ($) {
 
 /**
@@ -42649,7 +42649,7 @@ window.mathBox = function (element, options) {
 // Fetch shader from <script> tag by id
 MathBox.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && (elem.innerText || elem.textContent) || id;
+  return elem && elem.textContent || id;
 };
 
 Math.sign = function (x) {

--- a/build/MathBox-core.js
+++ b/build/MathBox-core.js
@@ -35,7 +35,7 @@ window.mathBox = function (element, options) {
 // Fetch shader from <script> tag by id
 MathBox.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && (elem.innerText || elem.textContent) || id;
+  return elem && elem.textContent || id;
 };
 
 Math.sign = function (x) {

--- a/build/MathBox.js
+++ b/build/MathBox.js
@@ -641,7 +641,7 @@ window.ThreeRTT = window.ThreeRTT || {};
 // or pass through string if not exists.
 ThreeRTT.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && elem.innerText || id;
+  return elem && elem.textContent || id;
 };
 
 // Simple loop helper
@@ -652,7 +652,7 @@ _.loop = function (n, callback) {
 // Fetch shader from <script> tag by id
 ThreeRTT.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && (elem.innerText || elem.textContent) || id;
+  return elem && elem.textContent || id;
 };
 // Check for a power of two.
 ThreeRTT.isPowerOfTwo = function (value) {
@@ -1848,7 +1848,7 @@ window.ShaderGraph = {};
 // Fetch shader from <script> tag by id
 ShaderGraph.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && (elem.innerText || elem.textContent) || id;
+  return elem && elem.textContent || id;
 };(function ($) {
 
 /**
@@ -3021,7 +3021,7 @@ window.mathBox = function (element, options) {
 // Fetch shader from <script> tag by id
 MathBox.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && (elem.innerText || elem.textContent) || id;
+  return elem && elem.textContent || id;
 };
 
 Math.sign = function (x) {

--- a/src/Common.js
+++ b/src/Common.js
@@ -35,7 +35,7 @@ window.mathBox = function (element, options) {
 // Fetch shader from <script> tag by id
 MathBox.getShader = function (id) {
   var elem = document.getElementById(id);
-  return elem && (elem.innerText || elem.textContent) || id;
+  return elem && elem.textContent || id;
 };
 
 Math.sign = function (x) {


### PR DESCRIPTION
Occurences of 'innerText' were replaced with 'textContent' for all files excluding external libraries.
This fix improves compatibility with IE11 by utilizing “textContent”, a W3C standard API. innerText logic handles newlines differently in different browsers, which can cause shader compilation problems.
