### PR TITLE
Option to animate immediately

### DIFF
--- a/src/Animator.js
+++ b/src/Animator.js
@@ -54,7 +54,7 @@ MathBox.Animator.prototype = {
         }
 
         // Stop all animations on the given keys
-        animator.stop(this, stop);
+        animator.stop(this, stop, true);
       }
 
       // Pass through to Attributes
@@ -84,11 +84,11 @@ MathBox.Animator.prototype = {
   /**
    * Stop all animations on an object.
    */
-  stop: function (object, keys) {
-    // Dequeue all animations, applying instantly.
+  stop: function (object, keys, apply) {
+    // Dequeue all animations, applying if requested.
     _.each(keys || object.__queue, function (queue, key) {
       while (object.__queue[key]) {
-        this.dequeue(object, key, true);
+        this.dequeue(object, key, apply);
       }
     }.bind(this));
   },
@@ -105,6 +105,10 @@ MathBox.Animator.prototype = {
     this.attach(object);
 
     _.each(attributes, function (value, key) {
+      if (options.immediately) {
+        this.stop(object, [key], false);
+      }
+
       // Init queue if necessary.
       var queue = object.__queue[key] = object.__queue[key] || [];
 

--- a/src/Animator.js
+++ b/src/Animator.js
@@ -74,7 +74,7 @@ MathBox.Animator.prototype = {
     factor = factor || 4;
 
     // Reduce
-    _.each(keys || object.__queue, function (queue, key) {
+    _.each(keys || object.__queue, function (key) {
       _.each(object.__queue[key], function (op) {
         op.hurry(factor);
       });
@@ -86,7 +86,7 @@ MathBox.Animator.prototype = {
    */
   stop: function (object, keys, apply) {
     // Dequeue all animations, applying if requested.
-    _.each(keys || object.__queue, function (queue, key) {
+    _.each(keys || object.__queue, function (key) {
       while (object.__queue[key]) {
         this.dequeue(object, key, apply);
       }

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -477,8 +477,8 @@ MathBox.Stage.prototype = _.extend(MathBox.Stage.prototype, {
     var animator = this.animator;
 
     _.each(this.select(selector, true), function (primitive) {
-      animator.stop(primitive, keys);
-      primitive.style && animator.stop(primitive.style, keys);
+      animator.stop(primitive, keys, true);
+      primitive.style && animator.stop(primitive.style, keys, true);
     });
 
     return this;


### PR DESCRIPTION
This option will remove all current animations (for the specified key) from the object without applying, before starting the requested animation. This allows for interrupting existing animations and smoothly moving to the final state.
